### PR TITLE
Request Spotify data & token

### DIFF
--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -75,7 +75,7 @@ const getToken = async (req, res) => {
     });
     const tokenData = await tokenResponse.json();
     // https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not
-    res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
+    res.setHeader('Cache-Control','max-age=0, s-maxage=3600');
     res.status(200).json(tokenData.access_token);
   } catch (error) {
     res.status(500).send(error.message);

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -1,48 +1,60 @@
 const fetch = require('node-fetch');
 const processErrorResponse = require('../utils/processErrorResponse.js');
-const { filterEmptyURL, sortByDate } = require('../utils/hnDataFilters');
-
-
-let token = {
-  'value': '',
-  'issued_at': ''
-}
 
 const getArtist = async (req, res) => {
   const { query } = req.params;
-  let currentToken = token.value;
+  let response;
+  let data;
   console.log("You've hit /api/spotify/artist with query: ", query)
   
+  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`;
+  // https://stackoverflow.com/a/10185427
+  const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken';
+
+  //making fetch call with relative path: https://stackoverflow.com/a/36369553
   try {
-    const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`
-    console.log('This is the URL, lads', URL)
+      let tokenResponse = await fetch(tokenAbsoluteURL);
+      let token = await tokenResponse.json();
+      console.log("logging from getArtist, value of token:", token)
+      // console.log("logging from getArtist handler: ", token)
+      response = await fetch(URL, {
+        headers: {
+            "Authorization": `Bearer ${token}`
+          },
+      });
+      data = await response.json();
+      
+      console.log("logging from getArtist, value of data:", data)
+      console.log("logging from getArtist, value of data.artists:", data.artists)
 
-    let response = await getSpotifySearch(URL, currentToken)
-    let data = await response.json();
-
-    
     //TODO: find a better way to handle retries? 
     // https://markmichon.com/automatic-retries-with-fetch
-    while (data?.error) {
-      if (data.error.status === 401) {
-        token = getSpotifyAccessToken();
-        response = await getSpotifySearch(URL, currentToken)
-        data = await response.json();
-      }
-    }
+    // if (data?.error) {
+    //   // console.log("There was an error (1st try): ", data.error.message);
+    //   let tokenResponse = await fetch(tokenAbsoluteURL);
+    //   let token = tokenResponse.json();
+    //   response = await fetch(URL, {
+    //     headers: {
+    //         "Authorization": `Bearer ${token}`
+    //       },
+    //   });
+    //   data = await response.json(); 
+    // }
+      
+    res.status(200).json(data.artists);
 
-    res.status(200).json(data.artists)
-  } catch (error) {  
-    let errMessage = `${error}`;
-    console.log("There was an error", errMessage);
-    processErrorResponse(res, 500, errMessage);  
+    } catch (error) {  
+      let errMessage = `${error}`;
+      console.log("There was an error 2nd try", errMessage);
+      processErrorResponse(res, 500, errMessage);  
   }
 }
 
 // Can I "save" the last token (or time of last token) between calls to Spotify using closure?
-const getSpotifySearch = async (url, token) => {  
+const getSpotifySearch = async (url, token) => {
+  // console.log("logging from getSpotifySearch...", token)  
   try {
-    const response = await fetch(URL, {
+    const response = await fetch(url, {
       headers: {
           "Authorization": `Bearer  ${token}`
         },
@@ -55,48 +67,49 @@ const getSpotifySearch = async (url, token) => {
 
   //TODO: um, this is a problem. https://developer.spotify.com/documentation/web-api/tutorials/getting-started#request-artist-data
   // Tokens are only valid for 1 hour :shrug
-const getSpotifyAccessToken = async() => {
+const getToken = async (req, res) => {
   try {
     const tokenResponse = await fetch("https://accounts.spotify.com/api/token", {
       method : 'POST',
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: `grant_type=client_credentials&client_id=${process.env.SPOTIFY_CLIENT_ID}&client_secret=${process.env.SPOTIFY_CLIENT_SECRET}`
     });
-    
-    const token = await tokenResponse.json().access_token;
-    return token
+    const tokenData = await tokenResponse.json();
+    // https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not
+    res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
+    res.status(200).json(tokenData.access_token);
   } catch (error) {
+    console.log('Error coming from getToken')
     throw new Error(`${error.message}`);
   }  
 }
 
-const getArticlesByQuery = async (req, res) => {
-  const { query } = req.params
-  console.log("You've hit /api/hackerNewsTest with query: ", query)
-  try { 
-    const URL = `https://hn.algolia.com/api/v1/search?query=${query}`;
-    const response = await fetch(URL, {
-      host: 'hn.algolia.com',
-      port: process.env.PORT || 8081,
-      path: `/api/v1/search?query=${query}`,
-      method : 'GET'
-    });
-    const data = await response.json();
-    const articles = data.hits;
+// const getArticlesByQuery = async (req, res) => {
+//   const { query } = req.params
+//   console.log("You've hit /api/hackerNewsTest with query: ", query)
+//   try { 
+//     const URL = `https://hn.algolia.com/api/v1/search?query=${query}`;
+//     const response = await fetch(URL, {
+//       host: 'hn.algolia.com',
+//       port: process.env.PORT || 8081,
+//       path: `/api/v1/search?query=${query}`,
+//       method : 'GET'
+//     });
+//     const data = await response.json();
+//     const articles = data.hits;
 
-    const filteredArticles = articles.filter(filterEmptyURL);
-    filteredArticles.sort(sortByDate)
+//     const filteredArticles = articles.filter(filterEmptyURL);
+//     filteredArticles.sort(sortByDate)
 
-    res.status(200).json(filteredArticles);
+//     res.status(200).json(filteredArticles);
 
-  } catch (err) {
-    let errMessage = `${err}`;
-    processErrorResponse(res, 500, errMessage); 
-  }
-}
+//   } catch (err) {
+//     let errMessage = `${err}`;
+//     processErrorResponse(res, 500, errMessage); 
+//   }
+// }
 
 module.exports = {
-  getArtist
+  getArtist,
+  getToken
 };

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -36,7 +36,7 @@ const getArtists = async (req, res) => {
   }
 }
 
-  const getToken = async (req, res) => {
+const getToken = async (req, res) => {
   try {
     if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
       throw new Error("No Spotify credentials provided"); 

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -1,14 +1,6 @@
 const fetch = require('node-fetch');
 const processErrorResponse = require('../utils/processErrorResponse.js');
 
-
-/*
-  TODO: how could I use the same endpoint/handler to search for artists AND tracks??
-  Returned JSON would still have a similar shape, maybe, like data.items, 
-  but they will have different properties that we care about for each.
-
-  Optional request params? One endpoint, multiple handlers?
-*/
 const getArtists = async (req, res) => {
   console.log("logging from getArtitsts, req.params and req.query", req.params, req.query);
   const { query, type } = req.params;
@@ -35,24 +27,7 @@ const getArtists = async (req, res) => {
           },
       });
       spotifyData = await spotifyResponse.json();
-
-    //TODO: find a better way to handle retries? 
-    // https://markmichon.com/automatic-retries-with-fetch
-    // if (spotifyData?.error) {
-    //   // console.log("There was an error (1st try): ", spotifyData.error.message);
-    //   let tokenResponse = await fetch(tokenAbsoluteURL);
-    //   let token = tokenResponse.json();
-    //   response = await fetch(URL, {
-    //     headers: {
-    //         "Authorization": `Bearer ${token}`
-    //       },
-    //   });
-    //   spotifyData = await response.json(); 
-    // }
-
-
-      
-    res.status(200).json(spotifyData[`${resourceType}s`]);
+      res.status(200).json(spotifyData[`${resourceType}s`]);
 
     } catch (error) {  
       let errMessage = `${error}`;
@@ -60,55 +35,6 @@ const getArtists = async (req, res) => {
       processErrorResponse(res, 500, errMessage);  
   }
 }
-
-// const getArtist = async (req, res) => {
-//   const { id } = req.params;
-//   if (!query) { res.status(204) };
-//   let spotifyResponse;
-//   let spotifyData;
-//   console.log("You've hit /api/spotify/artist with id: ", id)
-  
-//   const URL = `https://api.spotify.com/v1/artists/${encodeURIComponent(id)}`
-//   // https://stackoverflow.com/a/10185427
-//   const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken';
-
-//   //making fetch call with relative path: https://stackoverflow.com/a/36369553
-//   try {
-//       let tokenResponse = await fetch(tokenAbsoluteURL);
-//       let token = await tokenResponse.json();
-//       // console.log("logging from getArtists handler: ", token)
-//       spotifyResponse = await fetch(URL, {
-//         headers: {
-//             "Authorization": `Bearer ${token}`
-//           },
-//       });
-//       spotifyData = await spotifyResponse.json();
-
-//     //TODO: find a better way to handle retries? 
-//     // https://markmichon.com/automatic-retries-with-fetch
-//     // if (spotifyData?.error) {
-//     //   // console.log("There was an error (1st try): ", spotifyData.error.message);
-//     //   let tokenResponse = await fetch(tokenAbsoluteURL);
-//     //   let token = tokenResponse.json();
-//     //   response = await fetch(URL, {
-//     //     headers: {
-//     //         "Authorization": `Bearer ${token}`
-//     //       },
-//     //   });
-//     //   spotifyData = await response.json(); 
-//     // }
-      
-//     res.status(200).json(spotifyData.artist);
-
-//     } catch (error) {  
-//       let errMessage = `${error}`;
-//       console.log("There was an error 2nd try", errMessage);
-//       processErrorResponse(res, 500, errMessage);  
-//   }
-// }
-
-  //TODO: um, this is a problem. https://developer.spotify.com/documentation/web-api/tutorials/getting-started#request-artist-data
-  // Tokens are only valid for 1 hour :shrug
 
   const getToken = async (req, res) => {
   try {

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -2,27 +2,74 @@ const fetch = require('node-fetch');
 const processErrorResponse = require('../utils/processErrorResponse.js');
 const { filterEmptyURL, sortByDate } = require('../utils/hnDataFilters');
 
+
+let token = {
+  'value': '',
+  'issued_at': ''
+}
+
 const getArtist = async (req, res) => {
   const { query } = req.params;
+  let currentToken = token.value;
   console.log("You've hit /api/spotify/artist with query: ", query)
   
   try {
     const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`
     console.log('This is the URL, lads', URL)
-    
-    const response = await fetch(URL, {
-      headers: {
-        "Authorization": 'Bearer  BQAUpf_PzvIsGFdRKpvaOUcr70GIpX0ufvlhk9pSeeya4kl4YLvSIuAiZoJxa0B60pNkxMsqYdDZqlDvrtXTfAl9BdwbQ6--tEYODED2A_pWfMQjOgUj'
-      },
-    });
 
-    const data = await response.json();
-    console.log("data", data);
+    let response = await getSpotifySearch(URL, currentToken)
+    let data = await response.json();
+
+    
+    //TODO: find a better way to handle retries? 
+    // https://markmichon.com/automatic-retries-with-fetch
+    while (data?.error) {
+      if (data.error.status === 401) {
+        token = getSpotifyAccessToken();
+        response = await getSpotifySearch(URL, currentToken)
+        data = await response.json();
+      }
+    }
+
     res.status(200).json(data.artists)
   } catch (error) {  
     let errMessage = `${error}`;
+    console.log("There was an error", errMessage);
     processErrorResponse(res, 500, errMessage);  
   }
+}
+
+// Can I "save" the last token (or time of last token) between calls to Spotify using closure?
+const getSpotifySearch = async (url, token) => {  
+  try {
+    const response = await fetch(URL, {
+      headers: {
+          "Authorization": `Bearer  ${token}`
+        },
+      });
+    return response
+  } catch (error) {
+    throw new Error(`${error.message}`);
+  }
+}
+
+  //TODO: um, this is a problem. https://developer.spotify.com/documentation/web-api/tutorials/getting-started#request-artist-data
+  // Tokens are only valid for 1 hour :shrug
+const getSpotifyAccessToken = async() => {
+  try {
+    const tokenResponse = await fetch("https://accounts.spotify.com/api/token", {
+      method : 'POST',
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: `grant_type=client_credentials&client_id=${process.env.SPOTIFY_CLIENT_ID}&client_secret=${process.env.SPOTIFY_CLIENT_SECRET}`
+    });
+    
+    const token = await tokenResponse.json().access_token;
+    return token
+  } catch (error) {
+    throw new Error(`${error.message}`);
+  }  
 }
 
 const getArticlesByQuery = async (req, res) => {

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -15,8 +15,6 @@ const getArtist = async (req, res) => {
   try {
       let tokenResponse = await fetch(tokenAbsoluteURL);
       let token = await tokenResponse.json();
-      console.log("logging from getArtist, value of tokenResponse:", tokenResponse)
-      console.log("logging from getArtist, value of token:", token)
       // console.log("logging from getArtist handler: ", token)
       response = await fetch(URL, {
         headers: {
@@ -77,7 +75,26 @@ const getToken = async (req, res) => {
     res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
     res.status(200).json(tokenData.access_token);
   } catch (error) {
-    res.status(403).json(error.message);
+    throw new Error(`${error.message}`);
+  }  
+}
+
+const getToken = async (req, res) => {
+  try {
+    if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
+      throw new Error("No Spotify credentials provided"); 
+    }
+    const tokenResponse = await fetch("https://accounts.spotify.com/api/token", {
+      method : 'POST',
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: `grant_type=client_credentials&client_id=${process.env.SPOTIFY_CLIENT_ID}&client_secret=${process.env.SPOTIFY_CLIENT_SECRET}`
+    });
+    const tokenData = await tokenResponse.json();
+    // https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not
+    res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
+    res.status(200).json(tokenData.access_token);
+  } catch (error) {
+    res.status(500).send(error.message);
   }  
 }
 

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -65,22 +65,6 @@ const getSpotifySearch = async (url, token) => {
   // Tokens are only valid for 1 hour :shrug
 const getToken = async (req, res) => {
   try {
-    const tokenResponse = await fetch("https://accounts.spotify.com/api/token", {
-      method : 'POST',
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: `grant_type=client_credentials&client_id=${process.env.SPOTIFY_CLIENT_ID}&client_secret=${process.env.SPOTIFY_CLIENT_SECRET}`
-    });
-    const tokenData = await tokenResponse.json();
-    // https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not
-    res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
-    res.status(200).json(tokenData.access_token);
-  } catch (error) {
-    throw new Error(`${error.message}`);
-  }  
-}
-
-const getToken = async (req, res) => {
-  try {
     if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
       throw new Error("No Spotify credentials provided"); 
     }

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -1,11 +1,12 @@
 const fetch = require('node-fetch');
 const processErrorResponse = require('../utils/processErrorResponse.js');
 
-const getArtist = async (req, res) => {
+const getArtists = async (req, res) => {
   const { query } = req.params;
-  let response;
-  let data;
-  console.log("You've hit /api/spotify/artist with query: ", query)
+  if (!query) { res.status(204) };
+  let spotifyResponse;
+  let spotifyData;
+  console.log("You've hit /api/spotify/search with query: ", query)
   
   const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`;
   // https://stackoverflow.com/a/10185427
@@ -15,18 +16,18 @@ const getArtist = async (req, res) => {
   try {
       let tokenResponse = await fetch(tokenAbsoluteURL);
       let token = await tokenResponse.json();
-      // console.log("logging from getArtist handler: ", token)
-      response = await fetch(URL, {
+      // console.log("logging from getArtists handler: ", token)
+      spotifyResponse = await fetch(URL, {
         headers: {
             "Authorization": `Bearer ${token}`
           },
       });
-      data = await response.json();
+      spotifyData = await spotifyResponse.json();
 
     //TODO: find a better way to handle retries? 
     // https://markmichon.com/automatic-retries-with-fetch
-    // if (data?.error) {
-    //   // console.log("There was an error (1st try): ", data.error.message);
+    // if (spotifyData?.error) {
+    //   // console.log("There was an error (1st try): ", spotifyData.error.message);
     //   let tokenResponse = await fetch(tokenAbsoluteURL);
     //   let token = tokenResponse.json();
     //   response = await fetch(URL, {
@@ -34,10 +35,10 @@ const getArtist = async (req, res) => {
     //         "Authorization": `Bearer ${token}`
     //       },
     //   });
-    //   data = await response.json(); 
+    //   spotifyData = await response.json(); 
     // }
       
-    res.status(200).json(data.artists);
+    res.status(200).json(spotifyData.artists);
 
     } catch (error) {  
       let errMessage = `${error}`;
@@ -46,24 +47,56 @@ const getArtist = async (req, res) => {
   }
 }
 
-// Can I "save" the last token (or time of last token) between calls to Spotify using closure?
-const getSpotifySearch = async (url, token) => {
-  // console.log("logging from getSpotifySearch...", token)  
-  try {
-    const response = await fetch(url, {
-      headers: {
-          "Authorization": `Bearer  ${token}`
-        },
-      });
-    return response
-  } catch (error) {
-    throw new Error(`${error.message}`);
-  }
-}
+// const getArtist = async (req, res) => {
+//   const { id } = req.params;
+//   if (!query) { res.status(204) };
+//   let spotifyResponse;
+//   let spotifyData;
+//   console.log("You've hit /api/spotify/artist with id: ", id)
+  
+//   const URL = `https://api.spotify.com/v1/artists/${encodeURIComponent(id)}`
+//   // https://stackoverflow.com/a/10185427
+//   const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken';
+
+//   //making fetch call with relative path: https://stackoverflow.com/a/36369553
+//   try {
+//       let tokenResponse = await fetch(tokenAbsoluteURL);
+//       let token = await tokenResponse.json();
+//       // console.log("logging from getArtists handler: ", token)
+//       spotifyResponse = await fetch(URL, {
+//         headers: {
+//             "Authorization": `Bearer ${token}`
+//           },
+//       });
+//       spotifyData = await spotifyResponse.json();
+
+//     //TODO: find a better way to handle retries? 
+//     // https://markmichon.com/automatic-retries-with-fetch
+//     // if (spotifyData?.error) {
+//     //   // console.log("There was an error (1st try): ", spotifyData.error.message);
+//     //   let tokenResponse = await fetch(tokenAbsoluteURL);
+//     //   let token = tokenResponse.json();
+//     //   response = await fetch(URL, {
+//     //     headers: {
+//     //         "Authorization": `Bearer ${token}`
+//     //       },
+//     //   });
+//     //   spotifyData = await response.json(); 
+//     // }
+      
+//     res.status(200).json(spotifyData.artist);
+
+//     } catch (error) {  
+//       let errMessage = `${error}`;
+//       console.log("There was an error 2nd try", errMessage);
+//       processErrorResponse(res, 500, errMessage);  
+//   }
+// }
 
   //TODO: um, this is a problem. https://developer.spotify.com/documentation/web-api/tutorials/getting-started#request-artist-data
   // Tokens are only valid for 1 hour :shrug
-const getToken = async (req, res) => {
+
+  const getToken = async (req, res) => {
   try {
     if (!process.env.SPOTIFY_CLIENT_ID || !process.env.SPOTIFY_CLIENT_SECRET) {
       throw new Error("No Spotify credentials provided"); 
@@ -82,32 +115,7 @@ const getToken = async (req, res) => {
   }  
 }
 
-// const getArticlesByQuery = async (req, res) => {
-//   const { query } = req.params
-//   console.log("You've hit /api/hackerNewsTest with query: ", query)
-//   try { 
-//     const URL = `https://hn.algolia.com/api/v1/search?query=${query}`;
-//     const response = await fetch(URL, {
-//       host: 'hn.algolia.com',
-//       port: process.env.PORT || 8081,
-//       path: `/api/v1/search?query=${query}`,
-//       method : 'GET'
-//     });
-//     const data = await response.json();
-//     const articles = data.hits;
-
-//     const filteredArticles = articles.filter(filterEmptyURL);
-//     filteredArticles.sort(sortByDate)
-
-//     res.status(200).json(filteredArticles);
-
-//   } catch (err) {
-//     let errMessage = `${err}`;
-//     processErrorResponse(res, 500, errMessage); 
-//   }
-// }
-
 module.exports = {
-  getArtist,
+  getArtists,
   getToken
 };

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -8,8 +8,17 @@ const getArtist = async (req, res) => {
   
   try {
     const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`
-    console.log(URL)
-    res.status(200).json({'hello': 'world'})
+    console.log('This is the URL, lads', URL)
+    
+    const response = await fetch(URL, {
+      headers: {
+        "Authorization": 'Bearer  BQAUpf_PzvIsGFdRKpvaOUcr70GIpX0ufvlhk9pSeeya4kl4YLvSIuAiZoJxa0B60pNkxMsqYdDZqlDvrtXTfAl9BdwbQ6--tEYODED2A_pWfMQjOgUj'
+      },
+    });
+
+    const data = await response.json();
+    console.log("data", data);
+    res.status(200).json(data.artists)
   } catch (error) {  
     let errMessage = `${error}`;
     processErrorResponse(res, 500, errMessage);  

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -15,6 +15,7 @@ const getArtist = async (req, res) => {
   try {
       let tokenResponse = await fetch(tokenAbsoluteURL);
       let token = await tokenResponse.json();
+      console.log("logging from getArtist, value of tokenResponse:", tokenResponse)
       console.log("logging from getArtist, value of token:", token)
       // console.log("logging from getArtist handler: ", token)
       response = await fetch(URL, {
@@ -23,9 +24,6 @@ const getArtist = async (req, res) => {
           },
       });
       data = await response.json();
-      
-      console.log("logging from getArtist, value of data:", data)
-      console.log("logging from getArtist, value of data.artists:", data.artists)
 
     //TODO: find a better way to handle retries? 
     // https://markmichon.com/automatic-retries-with-fetch
@@ -79,8 +77,7 @@ const getToken = async (req, res) => {
     res.setHeader('Cache-Control','max-age=0, s-max-age=3600');
     res.status(200).json(tokenData.access_token);
   } catch (error) {
-    console.log('Error coming from getToken')
-    throw new Error(`${error.message}`);
+    res.status(403).json(error.message);
   }  
 }
 

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -10,13 +10,17 @@ const processErrorResponse = require('../utils/processErrorResponse.js');
   Optional request params? One endpoint, multiple handlers?
 */
 const getArtists = async (req, res) => {
-  const { query } = req.params;
+  console.log("logging from getArtitsts, req.params and req.query", req.params, req.query);
+  const { query, type } = req.params;
+  
   if (!query) { res.status(204) };
+  
   let spotifyResponse;
   let spotifyData;
-  console.log("You've hit /api/spotify/search with query: ", query)
-  
-  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist`;
+  let resourceType = type ? type : 'artist'
+
+  console.log("You've hit /api/spotify/search with query and type: ", query, type)
+  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=${resourceType}`;
   // https://stackoverflow.com/a/10185427
   const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken';
 
@@ -45,8 +49,10 @@ const getArtists = async (req, res) => {
     //   });
     //   spotifyData = await response.json(); 
     // }
+
+
       
-    res.status(200).json(spotifyData.artists);
+    res.status(200).json(spotifyData[`${resourceType}s`]);
 
     } catch (error) {  
       let errMessage = `${error}`;

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -1,0 +1,46 @@
+const fetch = require('node-fetch');
+const processErrorResponse = require('../utils/processErrorResponse.js');
+const { filterEmptyURL, sortByDate } = require('../utils/hnDataFilters');
+
+const getArtist = async (req, res) => {
+  const { query } = req.params;
+  console.log("You've hit /api/spotify/artist with query: ", query)
+  
+  try {
+    const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`
+    console.log(URL)
+    res.status(200).json({'hello': 'world'})
+  } catch (error) {  
+    let errMessage = `${error}`;
+    processErrorResponse(res, 500, errMessage);  
+  }
+}
+
+const getArticlesByQuery = async (req, res) => {
+  const { query } = req.params
+  console.log("You've hit /api/hackerNewsTest with query: ", query)
+  try { 
+    const URL = `https://hn.algolia.com/api/v1/search?query=${query}`;
+    const response = await fetch(URL, {
+      host: 'hn.algolia.com',
+      port: process.env.PORT || 8081,
+      path: `/api/v1/search?query=${query}`,
+      method : 'GET'
+    });
+    const data = await response.json();
+    const articles = data.hits;
+
+    const filteredArticles = articles.filter(filterEmptyURL);
+    filteredArticles.sort(sortByDate)
+
+    res.status(200).json(filteredArticles);
+
+  } catch (err) {
+    let errMessage = `${err}`;
+    processErrorResponse(res, 500, errMessage); 
+  }
+}
+
+module.exports = {
+  getArtist
+};

--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -1,6 +1,14 @@
 const fetch = require('node-fetch');
 const processErrorResponse = require('../utils/processErrorResponse.js');
 
+
+/*
+  TODO: how could I use the same endpoint/handler to search for artists AND tracks??
+  Returned JSON would still have a similar shape, maybe, like data.items, 
+  but they will have different properties that we care about for each.
+
+  Optional request params? One endpoint, multiple handlers?
+*/
 const getArtists = async (req, res) => {
   const { query } = req.params;
   if (!query) { res.status(204) };
@@ -8,7 +16,7 @@ const getArtists = async (req, res) => {
   let spotifyData;
   console.log("You've hit /api/spotify/search with query: ", query)
   
-  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist&tag:hipster`;
+  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=artist`;
   // https://stackoverflow.com/a/10185427
   const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken';
 

--- a/api/router.js
+++ b/api/router.js
@@ -9,6 +9,6 @@ const router = Router();
 
 router.get('/hn', getFrontPageArticles)
 router.get('/hn/:query', getArticlesByQuery)
-router.get('/spotify/artist/:query', getArtists)
+router.get('/spotify/search/:query', getArtists)
 
 module.exports = router;

--- a/api/router.js
+++ b/api/router.js
@@ -3,12 +3,12 @@ const {
   getArticlesByQuery, 
   getFrontPageArticles 
 } = require('./handlers/hackerNews');
-const { getArtist } = require('./handlers/spotify')
+const { getArtists } = require('./handlers/spotify')
 
 const router = Router();
 
 router.get('/hn', getFrontPageArticles)
 router.get('/hn/:query', getArticlesByQuery)
-router.get('/spotify/artist/:query', getArtist)
+router.get('/spotify/artist/:query', getArtists)
 
 module.exports = router;

--- a/api/router.js
+++ b/api/router.js
@@ -3,10 +3,12 @@ const {
   getArticlesByQuery, 
   getFrontPageArticles 
 } = require('./handlers/hackerNews');
+const { getArtist } = require('./handlers/spotify')
 
 const router = Router();
 
 router.get('/hn', getFrontPageArticles)
 router.get('/hn/:query', getArticlesByQuery)
+router.get('/spotify/artist/:query', getArtist)
 
 module.exports = router;

--- a/api/router.js
+++ b/api/router.js
@@ -9,6 +9,7 @@ const router = Router();
 
 router.get('/hn', getFrontPageArticles)
 router.get('/hn/:query', getArticlesByQuery)
-router.get('/spotify/search/:query', getArtists)
+// router.get('/spotify/search/:query/type/:type', getArtists)
+router.get('/spotify/search/:query/:type?', getArtists)
 
 module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,7 @@ const helmet = require('helmet');
 const morgan = require('morgan');
 const { protect } = require('./utils/auth');
 const router = require('./router');
+const { getToken } = require('./handlers/spotify')
 
 const app = express();
 // adding Helmet to enhance API's security
@@ -21,7 +22,9 @@ app.use(morgan('combined'));
 // https://www.freecodecamp.org/news/how-to-create-a-react-app-with-a-node-backend-the-complete-guide/
 app.use(express.static(path.resolve(__dirname, '../public')));
 
-// Authorize all /api requests
+// Authorize all /api except for spotify/ requests. 
+// Why? Because we want to cache this, and we can't have auth headers when caching: https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not
+app.use("/api/spotify/getToken", getToken);
 app.use("/api", protect(), router);
 
 // All other GET requests not handled before will return our React app

--- a/api/utils/spotifyDataFilters.js
+++ b/api/utils/spotifyDataFilters.js
@@ -1,0 +1,12 @@
+const filterEmptyURL = (article) => { 
+  return article.url && article?.url?.includes('http'); 
+};
+
+const sortTracksByPopularity = (trackA, trackB) => { 
+  return trackB.popularity - trackA.popularity 
+};
+
+module.exports = {
+  filterEmptyURL, 
+  sortTracksByPopularity
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,15 +47,14 @@ const App = () => {
         {status === "fetching" && <div className="loading" />}
         {status === "fetched" && (
           <>
-            <div className="query"> {query ? `Search results for ${query}` : 'Front page results'} </div>
-            {data.length === 0 && <div> No articles found! :( </div>}
-            {data.map(article => (
-              <div className="article" key={article.objectID}>
-                <a target="_blank" href={article.url} rel="noopener noreferrer">
-                  {article.title}
+            <div>Showing results for: <em>{query}</em></div>
+            {data.items.length < 1 && <div> No artists found!</div>}
+            {data.items.map(artist => (
+              <div className="article" key={artist.id}>
+                <a target="_blank" href={artist.external_urls.spotify} rel="noopener noreferrer">
+                  {artist.name}
                 </a>{" "}
-                by {article.author}
-              </div>
+              </div>              
             ))}
           </>
         )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useHN } from "./hooks/useHN";
+import { useSpotify } from "./hooks/useSpotify";
 import "./App.css";
 
 const App = () => {
@@ -13,12 +13,13 @@ const App = () => {
   const [query, setQuery] = useState("");
   // Avoids infinite loop cause by resetting requestOptions value on every re-render. We don't want fetchOptions to change.
   const [fetchOptions, ] = useState(requestOptions);
-  const { status, data, error } = useHN(query, fetchOptions);
+  const { status, data, error } = useSpotify(query, fetchOptions);
 
   const handleSubmit = e => {
     e.preventDefault();
 
     const search = e.target.search.value;
+    console.log(search)
     if (search) {
       setQuery(search);
       e.target.search.value = "";

--- a/src/hooks/useSpotify.js
+++ b/src/hooks/useSpotify.js
@@ -1,6 +1,5 @@
 import { useFetch } from "./useFetch";
 
 export const useSpotify = (query, options) => {
-  console.log(query)
   return useFetch(`api/spotify/search/${query}`, options);
 }

--- a/src/hooks/useSpotify.js
+++ b/src/hooks/useSpotify.js
@@ -1,0 +1,6 @@
+import { useFetch } from "./useFetch";
+
+export const useSpotify = (query, options) => {
+  console.log(query)
+  return useFetch(`api/spotify/artist/${query}`, options);
+}

--- a/src/hooks/useSpotify.js
+++ b/src/hooks/useSpotify.js
@@ -2,5 +2,5 @@ import { useFetch } from "./useFetch";
 
 export const useSpotify = (query, options) => {
   console.log(query)
-  return useFetch(`api/spotify/artist/${query}`, options);
+  return useFetch(`api/spotify/search/${query}`, options);
 }


### PR DESCRIPTION
Set up two endpoints to interact with Spotify's API: one to get search results, the other to request an access token.

The access token is valid for 1 hour (= 3,600 seconds). Using the `'Cache-Control','max-age=0, s-maxage=3600'` HTTP header, the response from our `/api/spotify/getToken` endpoint is cached for that long, therefore reducing API calls to Spotify (in case they have rate limits in place).

Two new env variables are needed to request a token: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`

TODOs: find a [better way to handle fetch retries](https://markmichon.com/automatic-retries-with-fetch
) when calls to Spotify's API fail? And/or better error handling?. Here's another idea: [JS fetch retry upon failure](https://dev.to/ycmjason/javascript-fetch-retry-upon-failure-3p6g )

Useful links:
- [Vercel-recommended cache headers](https://stackoverflow.com/a/74098171)
- [What gets cached by Vercel](https://vercel.com/docs/concepts/functions/serverless-functions/edge-caching#:~:text=header.-,Request%20must%20not%20contain%20the,header.,-Request%20must%20not)
- [NodeJs/Express: Authorise all endpoints except one](https://stackoverflow.com/questions/57134882/nodejs-express-authorise-all-endpoints-except-one](https://stackoverflow.com/a/57135261 )

