### PR TITLE
Brute-force getting all tracks by artist

### DIFF
--- a/api/handlers/spotify.js
+++ b/api/handlers/spotify.js
@@ -39,28 +39,16 @@ const getArtists = async (req, res) => {
       processErrorResponse(res, 500, errMessage);  
   }
 }
-
-// Need to figure out how to get tracks for a particular artist
-// Or how to filter tracks by a given artist from a tracks response
-const getTracks = async (req, res) => {
-  console.log("logging from getTracks MY LAD, req.params and req.query", req.params, req.query);
+const getTracks = async (req, res) => { 
   const { query } = req.params;
+  console.log("You've hit /api/spotify/search/tracks with query: ", query)
   
   if (!query) { res.status(204) };
 
   // Keys = track.name, and values = str of comma-separated track.artists
   const tracksAndArtistsCache = {};
-  const TRACKS_PER_PAGE = 50;
-  const MAX_TRACKS = 1000;
   let allTracksResults = [];
-  // let spotifyResponse;
-  // let spotifyData;
-
-  console.log("You've hit /api/spotify/search/tracks with query: ", query)
   
-  // How to get tracks for a given artist? Spotify doesn't provide this out of the box: 
-  // https://stackoverflow.com/questions/41110986/searching-in-an-artists-tracks-spotify-apis  
-  const URL = `https://api.spotify.com/v1/search?query=${encodeURIComponent(query)}&type=track&limit=50`;
   // https://stackoverflow.com/a/10185427
   const tokenAbsoluteURL = req.protocol + '://' + req.get('host') + '/api/spotify/getToken'; 
 
@@ -68,39 +56,45 @@ const getTracks = async (req, res) => {
       let tokenResponse = await fetch(tokenAbsoluteURL); //fetch call w/relative path: https://stackoverflow.com/a/36369553
       let token = await tokenResponse.json();
 
-      for (let i = 0; i < MAX_TRACKS / TRACKS_PER_PAGE; i++) {
-        console.log('FETCHING RESULTS FOR PAGE', i);
-        const spotifyRes = await fetch(`${URL}&offset=${TRACKS_PER_PAGE * i}`, {
-          headers: {
-            "Authorization": `Bearer ${token}`
-          }
-        });
-
-        const spotifyData = await spotifyRes.json();
-        allTracksResults = allTracksResults.concat(spotifyData.tracks.items);
-
-        if (spotifyData.tracks.items.length < 50) {
-          break;
+      let response = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=50`, {
+        headers: {
+          'Authorization': `Bearer ${token}`
         }
+      });
+
+      if (response.ok) {
+        let data = await response.json();
+        let tracks = data.tracks.items;
+
+        console.log('first page has been fetched. There are this many tracks: ', tracks.length);
+        allTracksResults = [...allTracksResults, ...tracks]    
+
+        while (data.tracks.next) {
+          response = await fetch(data.tracks.next, {
+            headers: {
+            Authorization: `Bearer ${token}`
+          }
+          });
+
+          if (response.ok) {
+            data = await response.json();
+            tracks = data.tracks.items;
+            allTracksResults = [...allTracksResults, ...tracks]
+          }
+        }
+      } else {
+        throw new Error('Failed to fetch first page of artist tracks');
       }
+      const tracksByArtist = allTracksResults.filter(containsArtist(query));
+      const uniqueTracksByArtist = tracksByArtist.filter(removeDuplicates(tracksAndArtistsCache))
 
-      console.log('THESE ARE ALL THE TRACKS!!', allTracksResults.length)
+      uniqueTracksByArtist.sort((a, b) => a.popularity - b.popularity);
 
-      const uniqueTracks = allTracksResults.filter(removeDuplicates(tracksAndArtistsCache));
-      const filteredTracks = uniqueTracks.filter(containsArtist(query));
-
-      res.status(200).json(filteredTracks);
-
-       
-      // // Good to have for debugging:
-      //   const duplicatedTracks = Object.keys(tracksAndArtistsCache);
-      //   console.log('LOGGING NAMES OF DUPLICATED TRACKS')
-      //   duplicatedTracks.forEach(trackName => console.log(`${trackName} by ${tracksAndArtistsCache[trackName]}`));
-
+      res.status(200).json(uniqueTracksByArtist.slice(0, 20));
 
     } catch (error) {  
       let errMessage = `${error}`;
-      console.log("There was an error on 2nd try", errMessage);
+      console.log(errMessage);
       processErrorResponse(res, 500, errMessage);  
   }
 }
@@ -129,3 +123,63 @@ module.exports = {
   getTracks,
   getToken
 };
+
+// const searchArtistTracks = async (artistName) => {
+//   try {
+//     // Encode the artist name for URL query
+//     const encodedArtistName = encodeURIComponent(artistName);
+
+//     // Initialize an empty array to store all the tracks
+//     let allTracks = [];
+
+//     // Make the initial fetch request to get the first page of tracks
+//     let response = await fetch(`https://api.spotify.com/v1/search?q=${encodedArtistName}&type=track&limit=50`, {
+//       headers: {
+//         Authorization: `Bearer ${YOUR_ACCESS_TOKEN}` // Replace with your actual access token
+//       }
+//     });
+
+//     if (response.ok) {
+//       const data = await response.json();
+//       const tracks = data.tracks.items;
+//       allTracks = [...allTracks, ...tracks]; // Add the tracks to the array
+
+//       // Check if there are more tracks, and fetch subsequent pages if needed
+//       while (data.tracks.next) {
+//         response = await fetch(data.tracks.next, { // Fetch the next page of tracks
+//           headers: {
+//             Authorization: `Bearer ${YOUR_ACCESS_TOKEN}` // Replace with your actual access token
+//           }
+//         });
+
+//         if (response.ok) {
+//           const data = await response.json();
+//           const tracks = data.tracks.items;
+//           allTracks = [...allTracks, ...tracks]; // Add the tracks to the array
+//         } else {
+//           // Handle error response
+//           throw new Error('Failed to fetch artist tracks');
+//         }
+//       }
+
+//       // Sort the tracks by popularity in ascending order
+//       allTracks.sort((a, b) => a.popularity - b.popularity);
+
+//       // Return the least popular tracks
+//       return allTracks;
+//     } else {
+//       // Handle error response
+//       throw new Error('Failed to fetch artist tracks');
+//     }
+//   } catch (error) {
+//     console.error(error);
+//   }
+// };
+// Note: As mentioned earlier, in the actual implementation, you will need to replace YOUR_ACCESS_TOKEN with your actual Spotify access token, which can be obtained through the Spotify Web API authorization process.
+
+
+
+
+// jasensio@ufm.edu
+// Write this function so that it uses a util function that gets an access token from Spotify and caches it for 1 hour 
+// Sure! H

--- a/api/utils/spotifyUtils.js
+++ b/api/utils/spotifyUtils.js
@@ -14,12 +14,9 @@ function buildArtistsString(artistsArr) {
   )
 }
 
-function containsArtist(artist) {
+function containsArtist(artistName) {
   return function(track) {
-      const artistsStr = buildArtistsString(track.artists);
-      const isArtistIncluded = artistsStr.toLowerCase().includes(artist.toLowerCase().trim());
-
-      return isArtistIncluded;
+      return track.artists.some(artist => artist.name.toLowerCase() === artistName.toLowerCase());
   }
 }
 

--- a/src/GetTracksBtn.jsx
+++ b/src/GetTracksBtn.jsx
@@ -48,9 +48,10 @@ const GetTracksBtn = ({ artist }) => {
       {trackData.length < 1 && <p>No track data yet...</p>}
         <ul>
           {trackData.map((track, i) => (
-            <li key={`${i}-${track.name}`}>{i}. {track.name} by {track.artists.reduce((accumulator, artistObj) => (
+            <li key={`${i}-${track.name}`}>{i}. <a href={track.external_urls.spotify}>{track.name}</a> by {track.artists.reduce((accumulator, artistObj) => (
             accumulator + ', ' + artistObj.name
             ), '')}
+            , <em>popularity: {track?.popularity}</em>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
### Some thoughts

Spotify's Search Web API uses pagination to respond with results. The max no. of results per "page" is 50, for a max number of results: 1000. 

Artists like Katy Perry have the max number of tracks allowed – all of 1,000. That means hitting the Spotify Search API 19 times in order to get all of them! And then we'd still be filtering out duplicates and sort by popularity (or sort by popularity as we fetch each page).

- So, how can we provide visual feedback to people using the app while we wait on this expensive "calculation"?

- Or should we start doing something ahead of time? In parallel? Is this possible?

- If we try to do this for several big artists in one go, will Spotify block us?